### PR TITLE
openssl: Build with GCC but in SUNW-fashion

### DIFF
--- a/openssl/Makefile
+++ b/openssl/Makefile
@@ -39,27 +39,27 @@ CONFIG_STATUS = config.status
 all: all32 all64
 
 all32: $(VER)/$(CONFIG_STATUS)
-	cd $(VER); env - PATH=/opt/SUNWspro/bin:$(PATH) \
+	cd $(VER); env - PATH=$(PATH) \
 	"CFLAGS=$(CFLAGS)" \
-	gmake
+	gmake 
 
 all64: $(VER64)/$(CONFIG_STATUS)
-	cd $(VER64); env - PATH=/opt/SUNWspro/bin:$(PATH) \
+	cd $(VER64); env - PATH=$(PATH) \
 	"CFLAGS=$(CFLAGS)" \
-	gmake
+	gmake 
 
 # opensslconf.h is patched to ensure suitability for both 64bit and 32bit
 $(VER)/$(CONFIG_STATUS): $(VER)/configure
-	cd $(VER); env - PATH=/opt/SUNWspro/bin:$(PATH) \
+	cd $(VER); env - PATH=$(PATH) \
 	ksh93 ./Configure $(CONFIGURE_OPTIONS) 
 	gpatch -p1 $(VER)/crypto/opensslconf.h opensslconf.patch
-	cd $(VER); gmake depend
+	cd $(VER); gmake  depend
 	touch $@
 
 $(VER64)/$(CONFIG_STATUS): $(VER)/configure
-	cd $(VER64); env - PATH=/opt/SUNWspro/bin:$(PATH) \
+	cd $(VER64); env - PATH=$(PATH) \
 	ksh93 ./Configure $(CONFIGURE_OPTIONS64)
-	cd $(VER64); gmake depend
+	cd $(VER64); gmake  depend
 	touch $@
 
 install: all install32 install64
@@ -73,10 +73,12 @@ install64: all64
 
 $(VER)/configure: $(VER).tar.gz
 	gzip -dc $(VER).tar.gz | tar xopf -
+	gpatch -p1 $(VER)/Configure configure.patch
 	mv $(VER) $(VER64)
 	touch $(VER64)/configure
 	gzip -dc $(VER).tar.gz | tar xopf -
 	touch $(VER)/configure
+	gpatch -p1 $(VER)/Configure configure.patch
 
 clean:
 	-rm -rf $(VER) $(VER64)

--- a/openssl/Makefile.com
+++ b/openssl/Makefile.com
@@ -44,7 +44,7 @@ GENERIC_CONFIGURE_OPTIONS = \
 	--openssldir=/etc/openssl \
 	--prefix=/usr \
 	--install_prefix=$(DESTDIR) \
- 	no-ec \
+	no-ec \
 	no-ecdh \
 	no-ecdsa \
 	no-rc3 \
@@ -61,16 +61,16 @@ GENERIC_CONFIGURE_OPTIONS = \
 	no-hw_padlock \
 	no-hw_sureware \
 	no-hw_ubsec \
- 	no-hw_cswift \
+	no-hw_cswift \
 	threads \
 	shared
 
-CONFIGURE_OPTIONS64_i386 = solaris64-x86_64-cc-sunw
+CONFIGURE_OPTIONS64_i386 = solaris64-x86_64-gcc-sunw
 CONFIGURE_OPTIONS64 = $(GENERIC_CONFIGURE_OPTIONS) \
 		$(CONFIGURE_OPTIONS64_i386) \
 		--pk11-libname=$(PKCS11_LIB64)
-			
-CONFIGURE_OPTIONS_i386 = solaris-x86-cc-sunw
+
+CONFIGURE_OPTIONS_i386 = solaris-x86-gcc-sunw
 CONFIGURE_OPTIONS = $(GENERIC_CONFIGURE_OPTIONS) \
 		$(CONFIGURE_OPTIONS_i386) \
 		--pk11-libname=$(PKCS11_LIB)

--- a/openssl/configure.patch
+++ b/openssl/configure.patch
@@ -1,0 +1,11 @@
+--- Configure.old	2012-02-27 22:28:07.873702428 -0500
++++ Configure	2012-02-27 22:28:42.733185196 -0500
+@@ -254,6 +254,8 @@
+ "solaris64-x86_64-cc-sunw","cc:-xO3 -m64 -g -xstrconst -Xa -DL_ENDIAN::-D_REENTRANT::-lsocket -lnsl -lc:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK BF_PTR DES_PTR DES_INT DES_UNROLL:${x86_64_asm_sunw}:dlfcn:solaris-shared:-KPIC:-m64 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign -M/usr/lib/ld/map.noexdata:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "solaris-sparcv8-cc-sunw","cc:-m32 -xregs=no%appl -xO5 -g -xstrconst -xdepend -Xa -DB_ENDIAN -DBN_DIV2W::-D_REENTRANT::-lsocket -lnsl -lc:BN_LLONG RC4_CHAR RC4_CHUNK DES_PTR DES_RISC1 DES_UNROLL BF_PTR::sparcv8plus.o::::::::::dlfcn:solaris-shared:-KPIC:-m32 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ "solaris64-sparcv9-cc-sunw","cc:-m64 -xregs=no%appl -xO5 -g -xstrconst -xdepend -xspace -Xa -DB_ENDIAN::-D_REENTRANT:ULTRASPARC:-lsocket -lnsl -lc:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL BF_PTR::::::::::::dlfcn:solaris-shared:-KPIC:-m64 -G -dy -z text -zdefs -Bdirect -zignore -M/usr/lib/ld/map.pagealign:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR):/usr/ccs/bin/ar rs",
++"solaris-x86-gcc-sunw","gcc:-O3 -fomit-frame-pointer -march=pentium -Wall -DL_ENDIAN -DOPENSSL_NO_INLINE_ASM::-D_REENTRANT::-lsocket -lnsl -ldl:BN_LLONG RC4_CHAR RC4_CHUNK BF_PTR ${x86_gcc_des} ${x86_gcc_opts}:${x86_elf_asm_sunw}:dlfcn:solaris-shared:-fPIC:-shared:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
++"solaris64-x86_64-gcc-sunw","gcc:-m64 -O3 -Wall -DL_ENDIAN -DMD32_REG_T=int::-D_REENTRANT::-lsocket -lnsl -ldl:SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_PTR DES_UNROLL BF_PTR:${x86_64_asm_sunw}:dlfcn:solaris-shared:-fPIC:-m64 -shared -static-libgcc:.so.\$(SHLIB_MAJOR).\$(SHLIB_MINOR)",
+ 
+ #### IRIX 5.x configs
+ # -mips2 flag is added by ./config when appropriate.


### PR DESCRIPTION
As with SunC, when building with GCC but for SunOS we need to make sure
that the integer type used by RC4 is always `char`.  This means defining
`RC4_CHAR` rather than `RC4_INT` but also disabling the use of the x86 ASM
RC4 implementation, which also assumes `RC4_INT` (this is what was missed
in 070825).

This is not exactly complete, in that someone should check the other differences between `...-cc` and `...-cc-sunw` and whether they should be applied (the ones that stand out are various linker flags for direct binding, and mapfiles we tend to use in the OS).  And other differences between `...-cc-sunw` and `...-gcc` and whether they're _really_ gcc-isms, or whether they are deviations from what we need.

When re-applying the changes I decided to use a -gcc-sunw to go with -cc-sunw to make the above comparisons easier, though I myself have only glanced at them, but these include the definition of `RC4_INDEX` and `DES_RISC1`

I've tested this, as far as it goes, by preloading a fixed libcrypto for a debug sshd and connecting to it both in general, and non-interactively with a DSA key (which is what triggers the most recent breakage)

@JohnSonnenschein and @jclulow have all the rest of the backstory here.
