### PR TITLE
OS-8402 patch CVE-2022-37434

### DIFF
--- a/libz/Patches/0001-CVE-2022-37434.patch
+++ b/libz/Patches/0001-CVE-2022-37434.patch
@@ -1,0 +1,15 @@
+diff -u a/inflate.c b/inflate.c
+--- a/inflate.c	2005-06-14 17:50:12.000000000 -0400
++++ b/inflate.c	2022-08-19 11:21:56.000000000 -0400
+@@ -682,8 +682,9 @@
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/node.js/Patches/0004-CVE-2022-37434.patch
+++ b/node.js/Patches/0004-CVE-2022-37434.patch
@@ -1,0 +1,14 @@
+--- a/deps/zlib/inflate.c	2014-02-18 18:34:29.000000000 -0500
++++ b/deps/zlib/inflate.c	2022-08-19 14:45:25.000000000 -0400
+@@ -683,8 +683,9 @@
+                 if (copy > have) copy = have;
+                 if (copy) {
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/nss-nspr/Patches/CVE-2022-37434.patch
+++ b/nss-nspr/Patches/CVE-2022-37434.patch
@@ -1,0 +1,14 @@
+--- a/nss/lib/zlib/inflate.c	2016-06-20 13:11:28.000000000 -0400
++++ b/nss/lib/zlib/inflate.c	2022-08-19 15:02:52.000000000 -0400
+@@ -720,8 +720,9 @@
+                 if (copy > have) copy = have;
+                 if (copy) {
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/perl/CVE-2022-37434.patch
+++ b/perl/CVE-2022-37434.patch
@@ -1,0 +1,14 @@
+--- a/cpan/Compress-Raw-Zlib/zlib-src/inflate.c	2011-01-09 15:20:53.000000000 -0500
++++ b/cpan/Compress-Raw-Zlib/zlib-src/inflate.c	2022-08-19 13:25:24.000000000 -0400
+@@ -683,8 +683,9 @@
+                 if (copy > have) copy = have;
+                 if (copy) {
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -54,6 +54,7 @@ NATIVE_SHARED_LDFLAGS = \
 	$(NATIVE_LDFLAGS)
 
 PATCHES += \
+	CVE-2022-37434.patch \
 	dtrace.patch \
 	native.patch \
 	fix-gcc-errno.patch

--- a/rsync/Patches/0011-CVE-2022-37434.patch
+++ b/rsync/Patches/0011-CVE-2022-37434.patch
@@ -1,0 +1,14 @@
+--- a/zlib/inflate.c	2013-06-10 01:27:33.000000000 -0400
++++ b/zlib/inflate.c	2022-08-19 15:05:41.000000000 -0400
+@@ -740,8 +740,9 @@
+                 if (copy > have) copy = have;
+                 if (copy) {
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
Built successfully, including 0-strap-cache.  Only question is do we need all of these ones patched or not.  My inclination is "yes, for safety," but I can be convinced otherwise.