### PR TITLE
OS-8426 rsync memory allocation issues

### DIFF
--- a/rsync/Patches/0012-allocation-fixes.patch
+++ b/rsync/Patches/0012-allocation-fixes.patch
@@ -1,0 +1,39 @@
+diff -ru a/proto.h b/proto.h
+--- a/proto.h	Tue Nov 29 14:47:49 2022
++++ b/proto.h	Tue Nov 29 14:49:53 2022
+@@ -395,8 +395,8 @@
+ void *expand_item_list(item_list *lp, size_t item_size,
+ 		       const char *desc, int incr);
+ int msleep(int t);
+-void *_new_array(unsigned long num, unsigned int size, int use_calloc);
+-void *_realloc_array(void *ptr, unsigned int size, size_t num);
++void *_new_array(size_t num, size_t size, int use_calloc);
++void *_realloc_array(void *ptr, size_t size, size_t num);
+ const char *sum_as_hex(const char *sum);
+ NORETURN void out_of_memory(const char *str);
+ NORETURN void overflow_exit(const char *str);
+diff -ru a/util2.c b/util2.c
+--- a/util2.c	Sat Aug  8 15:47:03 2015
++++ b/util2.c	Tue Nov 29 14:48:36 2022
+@@ -61,19 +61,13 @@
+ 	return True;
+ }
+ 
+-#define MALLOC_MAX 0x40000000
+-
+-void *_new_array(unsigned long num, unsigned int size, int use_calloc)
++void *_new_array(size_t num, size_t size, int use_calloc)
+ {
+-	if (num >= MALLOC_MAX/size)
+-		return NULL;
+ 	return use_calloc ? calloc(num, size) : malloc(num * size);
+ }
+ 
+-void *_realloc_array(void *ptr, unsigned int size, size_t num)
++void *_realloc_array(void *ptr, size_t size, size_t num)
+ {
+-	if (num >= MALLOC_MAX/size)
+-		return NULL;
+ 	if (!ptr)
+ 		return malloc(size * num);
+ 	return realloc(ptr, size * num);


### PR DESCRIPTION
This is the "patch 3.1.2" approach.  Doing a heavy lift to 3.2.7 may be not as hard as I fear, but this should fix the problem in the short term.