### PR TITLE
OS-8568 coreutils --help invocations of compiled binaries can explode

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -36,9 +36,16 @@ include ../Makefile.targ
 AUTOCONF_ENV.64 += FORCE_UNSAFE_CONFIGURE=1
 OVERRIDES.64 += FORCE_UNSAFE_CONFIGURE=1
 
+LD_LIBRARY_PATH_HACK = /tmp/extra-ldlibpath
+PATCHES = Patches/*
+
 all: all_autoconf
 
-install: all
+scribble_ld_library:
+	echo $(DESTDIR)/lib/64 > $(LD_LIBRARY_PATH_HACK)
+
+install: scribble_ld_library all
+	/bin/rm -rf $(LD_LIBRARY_PATH_PACK)
 	mkdir -p $(DESTDIR)/usr/bin
 	mkdir -p $(DESTDIR)/usr/share/man/man1
 	cp $(BASE)/$(VER.64)/src/readlink $(DESTDIR)/usr/bin

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -45,7 +45,7 @@ scribble_ld_library:
 	echo $(DESTDIR)/lib/64 > $(LD_LIBRARY_PATH_HACK)
 
 install: scribble_ld_library all
-	/bin/rm -rf $(LD_LIBRARY_PATH_PACK)
+	/bin/rm -f $(LD_LIBRARY_PATH_HACK)
 	mkdir -p $(DESTDIR)/usr/bin
 	mkdir -p $(DESTDIR)/usr/share/man/man1
 	cp $(BASE)/$(VER.64)/src/readlink $(DESTDIR)/usr/bin

--- a/coreutils/Patches/0001-use-new-libs.patch
+++ b/coreutils/Patches/0001-use-new-libs.patch
@@ -1,0 +1,16 @@
+diff -ru a/Makefile.in b/Makefile.in
+--- a/Makefile.in	Tue Aug 29 10:22:37 2023
++++ b/Makefile.in	Mon Aug 19 16:44:39 2024
+@@ -27789,8 +27789,10 @@
+ 	  && t=$*.td							\
+ 	  && rm -rf $$t							\
+ 	  && $(MKDIR_P) $$t						\
+-	  && (cd $$t && $(LN_S) '$(abs_top_builddir)/src/'$$prog$(EXEEXT) \
+-				$$argv$(EXEEXT))			\
++	  && (cd $$t && (echo "#!/bin/bash" &&				\
++		echo "export LD_LIBRARY_PATH=`cat /tmp/extra-ldlibpath`" && \
++		echo '$(abs_top_builddir)/src/'$$prog$(EXEEXT) '$$@' )	\
++			> $$argv$(EXEEXT) && chmod 0755 $$argv$(EXTEXT) ) \
+ 	&& : $${SOURCE_DATE_EPOCH=`cat $(srcdir)/.timestamp 2>/dev/null || :`} \
+ 	&& : $${TZ=UTC0} && export TZ					\
+ 	&& export SOURCE_DATE_EPOCH && $(run_help2man)			\


### PR DESCRIPTION
This is a requirement before accepting https://www.illumos.org/issues/16675 from upstream.

It has been tested locally with a smartos-live build with current `master` of illumos-joyent.  A merged illumos-joyent PLUS this is building locally now.  Also build 713 of  https://jenkins.tritondatacenter.com/job/TritonDataCenter/job/smartos-live/job/master/ is a reproduction of this change plus pre-merge illumos-joyent across all three build types (default, DEBUG, and gcc7).