### PR TITLE
OS-8569 OS-8568's fix should be cleaner

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -36,16 +36,11 @@ include ../Makefile.targ
 AUTOCONF_ENV.64 += FORCE_UNSAFE_CONFIGURE=1
 OVERRIDES.64 += FORCE_UNSAFE_CONFIGURE=1
 
-LD_LIBRARY_PATH_HACK = /tmp/extra-ldlibpath
 PATCHES = Patches/*
 
 all: all_autoconf
 
-scribble_ld_library:
-	echo $(DESTDIR)/lib/64 > $(LD_LIBRARY_PATH_HACK)
-
-install: scribble_ld_library all
-	/bin/rm -f $(LD_LIBRARY_PATH_HACK)
+install: all
 	mkdir -p $(DESTDIR)/usr/bin
 	mkdir -p $(DESTDIR)/usr/share/man/man1
 	cp $(BASE)/$(VER.64)/src/readlink $(DESTDIR)/usr/bin

--- a/coreutils/Patches/0001-use-new-libs.patch
+++ b/coreutils/Patches/0001-use-new-libs.patch
@@ -8,7 +8,7 @@ diff -ru a/Makefile.in b/Makefile.in
 -	  && (cd $$t && $(LN_S) '$(abs_top_builddir)/src/'$$prog$(EXEEXT) \
 -				$$argv$(EXEEXT))			\
 +	  && (cd $$t && (echo "#!/bin/bash" &&				\
-+		echo "export LD_LIBRARY_PATH=`cat /tmp/extra-ldlibpath`" && \
++		echo "export LD_LIBRARY_PATH=`echo $(abs_top_builddir) | sed 's/projects\/illumos-extra\/coreutils\/coreutils.*-64$$/proto\/lib\/64/g'`" && \
 +		echo '$(abs_top_builddir)/src/'$$prog$(EXEEXT) '$$@' )	\
 +			> $$argv$(EXEEXT) && chmod 0755 $$argv$(EXTEXT) ) \
  	&& : $${SOURCE_DATE_EPOCH=`cat $(srcdir)/.timestamp 2>/dev/null || :`} \


### PR DESCRIPTION
I am SO sorry for not coming up with this as part of OS-8568.  This contains the damage to `Makefile.in`.  It appears too that the `abs_top_builddir` variable is documented in automake, so I can indeed exploit this, along with sed(1) for fun, profit, and reverting the Makefile in `coreutils` to ONLY require a patch.