### PR TITLE
OS-8583 Update gcc10 to very latest illumos snapshot, 10.4.0-il-2

### DIFF
--- a/gcc10/Makefile
+++ b/gcc10/Makefile
@@ -11,6 +11,7 @@
 
 #
 # Copyright 2021 Joyent, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 #
@@ -26,7 +27,7 @@ BUILD64=yes
 BUILD32=
 
 GCC_VER = 10
-VER = gcc-10.4.0-il-1
+VER = gcc-10.4.0-il-2
 MPFR_VER = mpfr-4.2.0
 GMP_VER = gmp-6.2.1
 MPC_VER = mpc-1.3.1

--- a/gcc10/gcc-10.4.0-il-1.tar.gz.sha1
+++ b/gcc10/gcc-10.4.0-il-1.tar.gz.sha1
@@ -1,1 +1,0 @@
-d57b3b94d680e38d6b8c237bbd11c18ed42dcbe4

--- a/gcc10/gcc-10.4.0-il-2.tar.gz.sha1
+++ b/gcc10/gcc-10.4.0-il-2.tar.gz.sha1
@@ -1,0 +1,1 @@
+2378fec32507caba035a5dfefbf61061eae8c83d


### PR DESCRIPTION
Subject says it all.  Will kick off local build now (1220 US/Eastern).  If successful, should be done in 2hrs, 15mins, and will perform further tests.