### PR TITLE
OS-8590 nss-nspr update for gcc 14

### DIFF
--- a/nss-nspr/Patches/ecperf.patch
+++ b/nss-nspr/Patches/ecperf.patch
@@ -1,0 +1,18 @@
+--- a/nss/cmd/ecperf/ecperf.c	2016-06-20 17:11:28.000000000 +0000
++++ b/nss/cmd/ecperf/ecperf.c	2024-10-31 11:47:03.297310415 +0000
+@@ -140,6 +140,7 @@
+         }
+         threadData->count++;
+     }
++    threadData->p2 = NULL;
+     return;
+ }
+ 
+@@ -168,6 +169,7 @@
+         }
+         threadData->count++;
+     }
++    threadData->p2 = NULL;
+     return;
+ }
+ 

--- a/nss-nspr/Patches/jar.patch
+++ b/nss-nspr/Patches/jar.patch
@@ -1,0 +1,11 @@
+--- a/nss/lib/jar/jarfile.c	2016-06-20 17:11:28.000000000 +0000
++++ b/nss/lib/jar/jarfile.c	2024-10-31 11:36:22.718304546 +0000
+@@ -657,7 +657,7 @@
+ jar_listzip(JAR *jar, JAR_FILE fp)
+ {
+     ZZLink *ent;
+-    JAR_Item *it;
++    JAR_Item *it = NULL;
+     JAR_Physical *phy = NULL;
+     struct ZipLocal *Local = PORT_ZNew(struct ZipLocal);
+     struct ZipCentral *Central = PORT_ZNew(struct ZipCentral);

--- a/nss-nspr/Patches/pkcs12.patch
+++ b/nss-nspr/Patches/pkcs12.patch
@@ -1,0 +1,21 @@
+--- a/nss/lib/pkcs12/p12e.c	2016-06-20 17:11:28.000000000 +0000
++++ b/nss/lib/pkcs12/p12e.c	2024-10-31 11:34:08.985776010 +0000
+@@ -1642,12 +1642,12 @@
+     sec_pkcs12_encoder_destroy_context(p12enc);
+     if (p12exp->arena != NULL)
+ 	PORT_ArenaRelease(p12exp->arena, mark);
+-	if (salt) {
+-		SECITEM_ZfreeItem(salt, PR_TRUE);
+-	}
+-	if (params) {
+-		PK11_DestroyPBEParams(params);
+-	}
++    if (salt) {
++	SECITEM_ZfreeItem(salt, PR_TRUE);
++    }
++    if (params) {
++	PK11_DestroyPBEParams(params);
++    }
+ 
+     return NULL;
+ }

--- a/nss-nspr/Patches/sqlite.patch
+++ b/nss-nspr/Patches/sqlite.patch
@@ -23,3 +23,14 @@
    }
    if( pEList==0 ){
      pEList = sqlite3ExprListAppend(pParse, 0, sqlite3Expr(db,TK_ASTERISK,0));
+--- a/nss/lib/sqlite/sqlite3.c	2024-08-10 21:56:37.618421906 +0000
++++ b/nss/lib/sqlite/sqlite3.c	2024-10-31 11:25:29.296176331 +0000
+@@ -97170,7 +97170,7 @@
+   ** number of rows in the table. Or 10, if the estimated number of rows 
+   ** in the table is less than that.  */
+   a[0] = pIdx->pTable->nRowLogEst;
+-  if( a[0]<33 ) a[0] = 33;        assert( 33==sqlite3LogEst(10) );
++  if( a[0]<33 ) { a[0] = 33; }        assert( 33==sqlite3LogEst(10) );
+ 
+   /* Estimate that a[1] is 10, a[2] is 9, a[3] is 8, a[4] is 7, a[5] is
+   ** 6 and each subsequent value (if any) is 5.  */


### PR DESCRIPTION
1. leaking pointer to local variable (set field to NULL to prevent it as our work is done).
2. variable may be used uninitialized (initialize it to NULL).
3. misaligned statements in two locations.