### PR TITLE
OS-8592 dialog update for gcc 14

### DIFF
--- a/dialog/Makefile
+++ b/dialog/Makefile
@@ -35,3 +35,5 @@ AUTOCONF_OPTS += \
 
 include ../Makefile.targ
 include ../Makefile.targ.autoconf
+
+PATCHES = Patches/*

--- a/dialog/Patches/0001-configure.patch
+++ b/dialog/Patches/0001-configure.patch
@@ -1,0 +1,20 @@
+--- a/configure	2011-10-20 21:27:48.000000000 +0000
++++ b/configure	2024-11-01 21:24:35.301726636 +0000
+@@ -9442,7 +9442,7 @@
+ int
+ main ()
+ {
+-initscr(); tgoto("?", 0,0)
++initscr(); endwin()
+   ;
+   return 0;
+ }
+@@ -10780,7 +10780,7 @@
+ int
+ main ()
+ {
+-initscr(); tgoto("?", 0,0)
++initscr(); endwin()
+   ;
+   return 0;
+ }


### PR DESCRIPTION
dialog has configure error with gcc 14; in order to check for ncurses.h, it is using tgoto(), but tgoto() is not declared in ncurses.h at all. Use endwin() instead (as it is done in more recent dialog).
gcc 10 does emit warning, but gcc 14 does count it as an error:
`configure:10782:12: warning: implicit declaration of function 'tgoto' [-Wimplicit-function-declaration]`