### PR TITLE
OS-8594 mdb_v8 update for gcc 14

### DIFF
--- a/mdb_v8/Makefile
+++ b/mdb_v8/Makefile
@@ -28,6 +28,8 @@ VER =	mdb_v8-1.4.3
 include ../Makefile.defs
 include ../Makefile.targ
 
+PATCHES = Patches/*
+
 CLEANFILES += .unpack
 
 CTF_LIBS = $(VER)/build/ia32/mdb_v8.so \
@@ -66,5 +68,9 @@ $(VER)/GNUMakefile: $(VER).tar.gz
 	-rm -rf $(VER)
 	mkdir -p .unpack
 	gtar x -C .unpack -z --no-same-owner -f $(VER).tar.gz
+	for p in $(PATCHES); do \
+		echo "Applying $$p"; \
+		$(GPATCH) -d .unpack/$(VER) -p$(PATCHSTRIP) < "$$p" || exit 1; \
+	done
 	mv -f .unpack/$(VER) $(VER)
 	-rmdir .unpack

--- a/mdb_v8/Patches/gcc14.patch
+++ b/mdb_v8/Patches/gcc14.patch
@@ -1,0 +1,11 @@
+--- a/src/mdb_v8.c	2021-11-18 04:24:28.000000000 +0000
++++ b/src/mdb_v8.c	2024-11-04 08:42:27.895692677 +0000
+@@ -4628,7 +4628,7 @@
+ 	if (read_heap_maybesmi(&nargs, funcinfop,
+ 	    V8_OFF_SHAREDFUNCTIONINFO_LENGTH) == 0) {
+ 		uintptr_t argptr;
+-		char arg[10];
++		char arg[25];
+ 
+ 		if (mdb_vread(&argptr, sizeof (argptr),
+ 		    fptr + V8_OFF_FP_ARGS + nargs * sizeof (uintptr_t)) != -1 &&


### PR DESCRIPTION
This change can be implemented as patch in build system or directly in mdb_v8 repo, the core of the issue is about local buffer space being too small, we need 25 bytes, not 10.