### PR TITLE
OS-8596 openldap update for gcc 14

### DIFF
--- a/openldap/Patches/gcc14.patch
+++ b/openldap/Patches/gcc14.patch
@@ -1,0 +1,44 @@
+--- a/configure	2023-02-08 18:49:18.000000000 +0000
++++ b/configure	2024-11-04 22:00:14.208009078 +0000
+@@ -16651,6 +16651,8 @@
+ #include <sys/types.h>
+ #include <regex.h>
+ static char *pattern, *string;
++
++int
+ main()
+ {
+ 	int rc;
+@@ -21024,7 +21026,7 @@
+ int
+ main ()
+ {
+-pthread_detach(NULL);
++pthread_detach(0);
+   ;
+   return 0;
+ }
+--- a/libraries/libldap/thr_thr.c	2023-02-08 18:49:18.000000000 +0000
++++ b/libraries/libldap/thr_thr.c	2024-11-04 22:09:56.555660450 +0000
+@@ -22,6 +22,8 @@
+ #define LDAP_THREAD_IMPLEMENTATION
+ #include "ldap_thr_debug.h"	 /* May rename the symbols defined below */
+ 
++#include <thread.h>
++
+ /*******************
+  *                 *
+  * Solaris Threads *
+--- a/libraries/libldap/thr_posix.c	2023-02-08 18:49:18.000000000 +0000
++++ b/libraries/libldap/thr_posix.c	2024-11-04 22:19:27.888942926 +0000
+@@ -39,6 +39,10 @@
+ #include "ldap_thr_debug.h"	 /* May rename the symbols defined below */
+ #include <signal.h>			 /* For pthread_kill() */
+ 
++#if defined(HAVE_THR_YIELD)
++#include <thread.h>
++#endif
++
+ extern int ldap_int_stackguard;
+ 
+ #if HAVE_PTHREADS < 6


### PR DESCRIPTION
openldap has two problems:
1. pthread_detach() needs int, not pointer
2. thr_yield() needs thread.h.