### PR TITLE
OS-8599 binutils does needless link against libfl

### DIFF
--- a/binutils/patches/binutiles_libfl.patch
+++ b/binutils/patches/binutiles_libfl.patch
@@ -1,0 +1,11 @@
+--- binutils-2.34/binutils/Makefile.am	2020-01-18 15:55:47.000000000 +0000
++++ binutils-2.34-32strap/binutils/Makefile.am	2024-11-14 14:48:09.031007390 +0000
+@@ -33,7 +33,7 @@
+ YACC = `if [ -f ../bison/bison ]; then echo ../bison/bison -y -L$(srcdir)/../bison/; else echo @YACC@; fi`
+ YFLAGS = -d
+ LEX = `if [ -f ../flex/flex ]; then echo ../flex/flex; else echo @LEX@; fi`
+-LEXLIB = @LEXLIB@
++LEXLIB = # @LEXLIB@
+ 
+ # Automake 1.10+ disables lex and yacc output file regeneration if
+ # maintainer mode is disabled.  Avoid this.


### PR DESCRIPTION
I got build error while building binutils, proto.strap compiler failed to locate libfl. Investigating the issue, I have determined the binutils does not actually need to be linked against libfl at all. Therefore the fix would be a small patch of [Makefile.am](http://makefile.am/) to prevent libfl to be used to link the binaries.