### PR TITLE
OS-8728 Update OpenSSL to 3.0.20

### DIFF
--- a/openssl3/Makefile
+++ b/openssl3/Makefile
@@ -24,7 +24,7 @@
 # Copyright 2026 Edgecast Cloud LLC.
 #
 
-VER = openssl-3.0.19
+VER = openssl-3.0.20
 LIBVER =	3
 
 include ../Makefile.defs


### PR DESCRIPTION
Not yet tested, but the single patch applies to the 3.0.20 source without issue.  Will update this as need-be, and the ticket when I've tested.